### PR TITLE
Upgrade juce and tracktion to newer versions: M1 compatibility

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 juce_add_gui_app(Montage)
 juce_add_console_app(Tests)
 
@@ -30,6 +34,7 @@ target_compile_definitions(Montage PRIVATE
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_gui_app` call
     JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:Montage,JUCE_PRODUCT_NAME>"
     JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:Montage,JUCE_VERSION>"
+    JUCE_MODAL_LOOPS_PERMITTED=1
     ASSETS_DIR="${montage_SOURCE_DIR}/assets"
     PRE_POPULATE_DUMMY_DATA=1 # TODO: CMAKE: this should probably be in a gen expression
 )

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -3,13 +3,13 @@ include(FetchContent)
 FetchContent_Declare(
     JUCE
     GIT_REPOSITORY  https://github.com/juce-framework/JUCE
-    GIT_TAG         b8206e3604ebaca64779bf19f1613c373b9adf4f #v6.0.4
+    GIT_TAG         b4bc2c8710cd1b0ca0e992040c16f89c7e137e70 # develop branch on 23-11-2021
 )
 
 FetchContent_Declare(
     tracktion
     GIT_REPOSITORY  https://github.com/Tracktion/tracktion_engine
-    GIT_TAG         e1cfb5aa6423891803a42126eeec4d077a6c12aa # develop branch on 30-11-2020
+    GIT_TAG         50bd60a93ff54a297b3ed2f2e6f9f238cddf8605 # develop branch on 24-11-2021
 )
 
 FetchContent_Declare(
@@ -25,8 +25,3 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(JUCE tracktion Aleatoric Catch2)
-
-juce_add_modules(
-    ${tracktion_SOURCE_DIR}/modules/tracktion_engine
-    ${tracktion_SOURCE_DIR}/modules/tracktion_graph
-)


### PR DESCRIPTION
…compatibility with M1 Mac. Includes:

upgrade juce and tracktion versions by tagging git to newer specific commits in cmake fetch content
remove the need to add juce modules for tracktion as this is now done as part of either juce or tracktion cmake configs
set c++ 17 as required in cmake